### PR TITLE
Dockerfile to build working image

### DIFF
--- a/docker/rockylinux/Dockerfile
+++ b/docker/rockylinux/Dockerfile
@@ -1,8 +1,5 @@
 # Use Rocky Linux as the base image
-FROM rockylinux/rockylinux:8
-
-# Set environment variables to avoid prompts during package installation
-ENV DEBIAN_FRONTEND=noninteractive
+FROM rockylinux/rockylinux:8 as build
 
 # Add a label for the image author
 LABEL maintainer="arbaudie.it@gmail.com"
@@ -23,15 +20,14 @@ RUN curl -sSL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s
 WORKDIR /app
 
 # Clone your GitHub repository
-RUN git clone https://github.com/SylvainA77/json2sql-plugin.git .
+RUN git clone --depth 1 https://github.com/SylvainA77/json2sql-plugin.git .
 
 # Build your project
 RUN mkdir build && cd build && cmake .. && make
 
-# Expose the default MariaDB port
-EXPOSE 3306
-# Expose the defaul json2sql port
-EXPOSE 3000
+FROM mariadb:latest
 
-# Start command for the container (MariaDB will not auto-start)
-CMD ["/bin/bash"]
+COPY --from=build /app/plugin/libjson2sql.so /usr/lib/mysql/plugin
+RUN printf "[mariadb]\nplugin-load-add=libjson2sql\n" > /etc/mysql/mariadb.conf.d/load_jsonplugin.cnf
+# Expose the default json2sql port
+EXPOSE 3000


### PR DESCRIPTION
```
$ buildah bud 
[1/2] STEP 1/11: FROM rockylinux/rockylinux:8 AS build
[1/2] STEP 2/11: LABEL maintainer="arbaudie.it@gmail.com"
--> Using cache 3e0a7cbdc37b37ec75ae700250355c8aace77188d0009bb14cdc2ecabcacb01b
--> 3e0a7cbdc37b
[1/2] STEP 3/11: RUN dnf update -y && yum install -y epel-release
Rocky Linux 8 - AppStream                       2.8 MB/s |  14 MB     00:05    
Rocky Linux 8 - BaseOS                          2.6 MB/s | 9.4 MB     00:03    
...                             

Complete!
53 files removed
--> a32d9b65a458
[1/2] STEP 8/11: WORKDIR /app
--> 0f3e0c08e3e7
[1/2] STEP 9/11: RUN git clone --depth 1 https://github.com/SylvainA77/json2sql-plugin.git .
Cloning into '.'...
--> eca5aa99c37f
[1/2] STEP 10/11: RUN mkdir build && cd build && cmake .. && make
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.6s)
-- Generating done (0.0s)
-- Build files have been written to: /app/build
[ 50%] Building C object CMakeFiles/json2sql.dir/code/json-api.c.o
[100%] Linking C shared module /app/plugin/libjson2sql.so
[100%] Built target json2sql
--> 7000c2081925
[2/2] STEP 1/4: FROM mariadb:latest
[2/2] STEP 2/4: COPY --from=build /app/plugin/libjson2sql.so /usr/lib/mysql/plugin
--> 5446f436d03c
[2/2] STEP 3/4: RUN printf "[mariadb]\nplugin-load-add=libjson2sql\n" > /etc/mysql/mariadb.conf.d/load_jsonplugin.cnf
--> dce8177279d1
[2/2] STEP 4/4: EXPOSE 3000
[2/2] COMMIT
--> cc21142723e5
cc21142723e548e7421271519c7cf6f881c21b4d78faf61bf5044646c0341c7d
```

And run:
```
$  podman run --rm --env MARIADB_ROOT_PASSWORD=bob -p 3000 --name mjson2 cc21142723e5
2024-12-06 04:56:35+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:11.6.2+maria~ubu2404 started.
2024-12-06 04:56:36+00:00 [Warn] [Entrypoint]: /sys/fs/cgroup///memory.pressure not writable, functionality unavailable to MariaDB
2024-12-06 04:56:36+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2024-12-06 04:56:36+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:11.6.2+maria~ubu2404 started.
2024-12-06 04:56:36+00:00 [Note] [Entrypoint]: Initializing database files
2024-12-06  4:56:36 0 [ERROR] mariadbd: Can't open shared library '/usr/lib/mysql/plugin/libjson2sql.so' (errno: 2, undefined symbol: mysql_query)
2024-12-06  4:56:36 0 [ERROR] Couldn't load plugins from 'libjson2sql.so'.
```

So running missing this symbol resolution, but the integration is there.